### PR TITLE
Update to GeoTools 30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,10 +148,10 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.11.0</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
-            <testSource>1.8</testSource>
-            <testTarget>1.8</testTarget>
+            <source>17</source>
+            <target>17</target>
+            <testSource>17</testSource>
+            <testTarget>17</testTarget>
             <forceJavacCompilerUse>true</forceJavacCompilerUse>
           </configuration>
         </plugin>

--- a/src/main/java/de/terrestris/filterfunctions/StringFormatFunction.java
+++ b/src/main/java/de/terrestris/filterfunctions/StringFormatFunction.java
@@ -1,8 +1,8 @@
 package de.terrestris.filterfunctions;
 
+import org.geotools.api.filter.capability.FunctionName;
 import org.geotools.filter.FunctionExpressionImpl;
 import org.geotools.filter.capability.FunctionNameImpl;
-import org.opengis.filter.capability.FunctionName;
 
 import static org.geotools.filter.capability.FunctionNameImpl.parameter;
 


### PR DESCRIPTION
Fixes the filter function to work with GeoTools 30. Also updates the required Java version to 17.

@terrestris/devs Please review.